### PR TITLE
Allows maps to  define specific areas to save by default

### DIFF
--- a/mods/persistence/_maps.dm
+++ b/mods/persistence/_maps.dm
@@ -1,2 +1,3 @@
 /datum/map
 	var/list/saved_levels = list()   // Z-levels that will be persisted to a database layer during saving intervals. 
+	var/list/saved_areas = list() // Areas that will be persisted to the database during saving intervals

--- a/mods/persistence/controllers/subsystems/persistence.dm
+++ b/mods/persistence/controllers/subsystems/persistence.dm
@@ -23,6 +23,7 @@
 
 /datum/controller/subsystem/persistence/Initialize()
 	saved_levels = global.using_map.saved_levels
+	saved_areas = global.using_map.saved_areas
 
 /datum/controller/subsystem/persistence/proc/SaveExists()
 	if(!save_exists)


### PR DESCRIPTION
## Description of changes
Adds a table to maps that allows you to define areas to be saved/loaded persistently.

## Why and what will this PR improve
This will be useful for defining areas outside of saving Z-levels for persistence. F.ex. the area immediately around the ladders on mining Z-levels, a set of buried ruins, the interior of a space station, or anything else that you'd want to be persistent in an otherwise non-saving Z-level.

## Draft PR
Pending review and approval [upstream](https://github.com/PersistentSS13/Nebula/pull/263) prior to merging, in case of unforeseen issues.

Merged Upstream: - [ ]

## Changelog

:cl:
tweak: Added saved_areas var to maps
/:cl:
